### PR TITLE
Move away from splitting on newlines to avoid OS-specific issues

### DIFF
--- a/DuoUniversal.Tests/TestCertPinning.cs
+++ b/DuoUniversal.Tests/TestCertPinning.cs
@@ -71,7 +71,7 @@ namespace DuoUniversal.Tests
         [Test]
         public void TestReadCertFile()
         {
-            Assert.AreEqual(CertificatePinnerFactory.ReadCertsFromFile().Length, 10);
+            Assert.AreEqual(10, CertificatePinnerFactory.ReadCertsFromFile().Length);
         }
 
         [Test]

--- a/DuoUniversal/CertificatePinnerFactory.cs
+++ b/DuoUniversal/CertificatePinnerFactory.cs
@@ -136,8 +136,8 @@ namespace DuoUniversal
             {
                 certs = reader.ReadToEnd();
             }
-            var twoNewlines = $"{Environment.NewLine}{Environment.NewLine}";
-            return certs.Split(new string[] { twoNewlines }, int.MaxValue, StringSplitOptions.None);
+            var splitOn = "-----DUO_CERT-----";
+            return certs.Split(new string[] { splitOn }, int.MaxValue, StringSplitOptions.None);
         }
     }
 }

--- a/DuoUniversal/ca_certs.pem
+++ b/DuoUniversal/ca_certs.pem
@@ -21,7 +21,7 @@ NW1fiQG2SVufAQWbqz0lwcy2f8Lxb4bG+mRo64EtlOtCt/qMHt1i8b5QZ7dsvfPx
 H2sMNgcWfzd8qVttevESRmCD1ycEvkvOl77DZypoEd+A5wwzZr8TDRRu838fYxAe
 +o0bJW1sj6W3YQGx0qMmoRBxna3iw/nDmVG3KwcIzi7mULKn+gpFL6Lw8g==
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject= /C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert Global Root CA
 -----BEGIN CERTIFICATE-----
 MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh
@@ -45,7 +45,7 @@ PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls
 YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk
 CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject= /C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert High Assurance EV Root CA
 -----BEGIN CERTIFICATE-----
 MIIDxTCCAq2gAwIBAgIQAqxcJmoLQJuPC3nyrkYldzANBgkqhkiG9w0BAQUFADBs
@@ -70,7 +70,7 @@ Yzi9RKR/5CYrCsSXaQ3pjOLAEFe4yHYSkVXySGnYvCoCWw9E1CAx2/S6cCZdkGCe
 vEsXCS+0yx5DaMkHJ8HSXPfqIbloEpw8nL+e/IBcm2PN7EeqJSdnoDfzAIJ9VNep
 +OkuE6N36B9K
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject= /C=US/O=SecureTrust Corporation/CN=SecureTrust CA
 -----BEGIN CERTIFICATE-----
 MIIDuDCCAqCgAwIBAgIQDPCOXAgWpa1Cf/DrJxhZ0DANBgkqhkiG9w0BAQUFADBI
@@ -94,7 +94,7 @@ D5kuCLDv/WnPmRoJjeOnnyvJNjR7JLN4TJUXpAYmHrZkUjZfYGfZnMUFdAvnZyPS
 CPyI6a6Lf+Ew9Dd+/cYy2i2eRDAwbO4H3tI0/NL/QPZL9GZGBlSm8jIKYyYwa5vR
 3ItHuuG51WLQoqD0ZwV4KWMabwTW+MZMo5qxN7SN5ShLHZ4swrhovO0C7jE=
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject= /C=US/O=SecureTrust Corporation/CN=Secure Global CA
 -----BEGIN CERTIFICATE-----
 MIIDvDCCAqSgAwIBAgIQB1YipOjUiolN9BPI8PjqpTANBgkqhkiG9w0BAQUFADBK
@@ -118,7 +118,7 @@ I50mD1hp/Ed+stCNi5O/KU9DaXR2Z0vPB4zmAve14bRDtUstFJ/53CYNv6ZHdAbY
 iNE6KTCEztI5gGIbqMdXSbxqVVFnFUq+NQfk1XWYN3kwFNspnWzFacxHVaIw98xc
 f8LDmBxrThaA63p4ZUWiABqvDA1VZDRIuJK58bRQKfJPIx/abKwfROHdI3hRW8cW
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject=C = US, O = Amazon, CN = Amazon Root CA 1
 -----BEGIN CERTIFICATE-----
 MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF
@@ -140,7 +140,7 @@ o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU
 5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy
 rqXRfboQnoZsG4q5WTP468SQvvG5
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject=C = US, O = Amazon, CN = Amazon Root CA 2
 -----BEGIN CERTIFICATE-----
 MIIFQTCCAymgAwIBAgITBmyf0pY1hp8KD+WGePhbJruKNzANBgkqhkiG9w0BAQwF
@@ -173,7 +173,7 @@ n749sSmvZ6ES8lgQGVMDMBu4Gon2nL2XA46jCfMdiyHxtN/kHNGfZQIG6lzWE7OE
 9jVlpNMKVv/1F2Rs76giJUmTtt8AF9pYfl3uxRuw0dFfIRDH+fO6AgonB8Xx1sfT
 4PsJYGw=
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject=C = US, O = Amazon, CN = Amazon Root CA 3
 -----BEGIN CERTIFICATE-----
 MIIBtjCCAVugAwIBAgITBmyf1XSXNmY/Owua2eiedgPySjAKBggqhkjOPQQDAjA5
@@ -187,7 +187,7 @@ ttvXBp43rDCGB5Fwx5zEGbF4wDAKBggqhkjOPQQDAgNJADBGAiEA4IWSoxe3jfkr
 BqWTrBqYaGFy+uGh0PsceGCmQ5nFuMQCIQCcAu/xlJyzlvnrxir4tiz+OpAUFteM
 YyRIHN8wfdVoOw==
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject=C = US, O = Amazon, CN = Amazon Root CA 4
 -----BEGIN CERTIFICATE-----
 MIIB8jCCAXigAwIBAgITBmyf18G7EEwpQ+Vxe3ssyBrBDjAKBggqhkjOPQQDAzA5
@@ -202,7 +202,7 @@ MAoGCCqGSM49BAMDA2gAMGUCMDqLIfG9fhGt0O9Yli/W651+kI0rz2ZVwyzjKKlw
 CkcO8DdZEv8tmZQoTipPNU0zWgIxAOp1AE47xDqUEpHJWEadIRNyp4iciuRMStuW
 1KyLa2tJElMzrdfkviT8tQp21KW8EA==
 -----END CERTIFICATE-----
-
+-----DUO_CERT-----
 subject=C = BM, O = QuoVadis Limited, CN = QuoVadis Root CA 2
 -----BEGIN CERTIFICATE-----
 MIIFtzCCA5+gAwIBAgICBQkwDQYJKoZIhvcNAQEFBQAwRTELMAkGA1UEBhMCQk0x


### PR DESCRIPTION
Attempt to address Issues 3 and 4 by using a fixed string to split on, rather than line endings, since the line endings approach seems to cause OS specific issues.