### PR TITLE
Use fixed cert validation datetime

### DIFF
--- a/DuoUniversal.Tests/TestCertPinning.cs
+++ b/DuoUniversal.Tests/TestCertPinning.cs
@@ -24,6 +24,7 @@ namespace DuoUniversal.Tests
         {
             // The certificate chain for api-*.duosecurity.com
             var chain = new X509Chain();
+            chain.ChainPolicy.VerificationTime = new DateTime(2023, 01, 01);
             chain.ChainPolicy.ExtraStore.Add(CertFromString(DUO_API_CERT_ROOT));
             chain.ChainPolicy.ExtraStore.Add(CertFromString(DUO_API_CERT_INTER));
             bool valid = chain.Build(DuoApiServerCert());
@@ -35,6 +36,7 @@ namespace DuoUniversal.Tests
         {
             // A valid chain, but for www.microsoft.com, not Duo
             var chain = new X509Chain();
+            chain.ChainPolicy.VerificationTime = new DateTime(2023, 01, 01);
             chain.ChainPolicy.ExtraStore.Add(CertFromString(MICROSOFT_COM_CERT_ROOT));
             chain.ChainPolicy.ExtraStore.Add(CertFromString(MICROSOFT_COM_CERT_INTER));
             bool valid = chain.Build(CertFromString(MICROSOFT_COM_CERT_SERVER));


### PR DESCRIPTION
to avoid having recurring certificate expiration test failures

This is the fix we used for the same issue in https://github.com/duosecurity/duo_api_csharp/commit/5c6b37603fb286962d757c23828060150ada8b31