### PR TITLE
Pad the JWT secret out to 64 bytes if necessary

### DIFF
--- a/DuoUniversal/JwtUtils.cs
+++ b/DuoUniversal/JwtUtils.cs
@@ -226,10 +226,15 @@ namespace DuoUniversal
         /// Generate a SecurityKey for the given shared secret 
         /// </summary>
         /// <param name="secret">The shared secret</param>
-        /// <returns>A SecurityKey encoding thae share secret</returns>
+        /// <returns>A SecurityKey encoding the shared secret</returns>
         private static SecurityKey GenerateSecurityKey(string secret)
         {
             byte[] keyBytes = Encoding.UTF8.GetBytes(secret);
+            // In case anything wants to enforce the correct key size, pad out to 64 bytes
+            if (keyBytes.Length < 64)
+            {
+                Array.Resize(ref keyBytes, 64);
+            }
             return new SymmetricSecurityKey(keyBytes);
         }
     }


### PR DESCRIPTION
## Description
The JWT secret will be padded (with zeroes) out to 64 bytes if necessary

## Motivation and Context
The newest version of the Microsoft JWT library enforces key lengths on the hashing algorithms now.  We use the Duo Client Secret as the JWT secret for HMAC, but that's only 40 bytes, so signing is failing for clients that use the latest JWT library version.

Fixes https://github.com/duosecurity/duo_universal_csharp/issues/22

## How Has This Been Tested?
Manually tested, plus the automated tests already test short secrets.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
