### PR TITLE
Adding .NET Framework 4.7.1 to the target frameworks

### DIFF
--- a/DuoUniversal/DuoUniversal.csproj
+++ b/DuoUniversal/DuoUniversal.csproj
@@ -4,9 +4,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <PackageId>DuoUniversal</PackageId>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Authors>Duo Security</Authors>
     <Company>Duo Security</Company>
     <Copyright>Cisco Systems, Inc. and/or its affiliates</Copyright>
@@ -17,6 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <Description>Duo two-factor authentication for .NET web applications</Description>
     <PackageProjectUrl>https://github.com/duosecurity/duo_universal_csharp</PackageProjectUrl>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> 
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +26,10 @@
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net471'">
+    <Reference Include="System.Web" />
+	</ItemGroup>
+		
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>DuoUniversal.Tests</_Parameter1>


### PR DESCRIPTION
Adding .NET Framework 4.7.1 to the target frameworks, bumping the version to 1.2.3

## Description
Modified the project file to accommodate the .NET Framework 4.7.1 support 

## Motivation and Context
Current DuoEpicHyperdrive integration runs on old environments, the min support version 4.6.1 of .NET Framework, but Epic overall is fine to target 4.7.1 on our end. The existing dll, targeting netstandard 2.0 has compatibility issues, which can be resolved either with a binding redirect (which requires modification of the files in the customer's app folder) or the current solution, which is implementing the binding in the code, but needs a dll, specifically targeting version 4.7.1, otherwise there are compatibility issues with the System.Text.Json lib and System.Runtime.CompilerServices.Unsafe. 

## How Has This Been Tested?
Using the local builds and running with the Epic's test harness app doesn't throw incompatibility exceptions when testing.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
