### PR TITLE
Adding a method for exchanging 2FA token to the SAML response

### DIFF
--- a/DuoUniversal.Tests/TestGenerateAuthUrl.cs
+++ b/DuoUniversal.Tests/TestGenerateAuthUrl.cs
@@ -36,7 +36,7 @@ namespace DuoUniversal.Tests
         [TestCase("user@foo.bar")]
         public void TestSuccessWithIssuer(string username)
         {
-            Client clientWithIssuer = new ClientBuilder(CLIENT_ID, CLIENT_SECRET, API_HOST, REDIRECT_URI).UseAudienceIssuer("http://issuer").Build();
+            Client clientWithIssuer = new ClientBuilder(CLIENT_ID, CLIENT_SECRET, API_HOST, REDIRECT_URI).UseAudienceForSamlResponse("http://issuer").Build();
             string authUri = clientWithIssuer.GenerateAuthUri(username, STATE);
             Assert.True(Uri.IsWellFormedUriString(authUri, UriKind.Absolute));
             Assert.True(authUri.StartsWith($"https://{API_HOST}"));
@@ -46,7 +46,7 @@ namespace DuoUniversal.Tests
         [TestCase("  ")]
         public void TestInvalidIssuer(string issuer)
         {
-            Client clientWithIssuer = new ClientBuilder(CLIENT_ID, CLIENT_SECRET, API_HOST, REDIRECT_URI).UseAudienceIssuer(issuer).Build();
+            Client clientWithIssuer = new ClientBuilder(CLIENT_ID, CLIENT_SECRET, API_HOST, REDIRECT_URI).UseAudienceForSamlResponse(issuer).Build();
             Assert.Throws<DuoException>(() => clientWithIssuer.GenerateAuthUri("username", STATE));
         }
 
@@ -54,7 +54,7 @@ namespace DuoUniversal.Tests
         [TestCase(null)]
         public void TestNullIssuer(string issuer)
         {
-            Client clientWithIssuer = new ClientBuilder(CLIENT_ID, CLIENT_SECRET, API_HOST, REDIRECT_URI).UseAudienceIssuer(issuer).Build();
+            Client clientWithIssuer = new ClientBuilder(CLIENT_ID, CLIENT_SECRET, API_HOST, REDIRECT_URI).UseAudienceForSamlResponse(issuer).Build();
             string authUri = clientWithIssuer.GenerateAuthUri("username", STATE);
             Assert.True(Uri.IsWellFormedUriString(authUri, UriKind.Absolute));
         }

--- a/DuoUniversal/Client.cs
+++ b/DuoUniversal/Client.cs
@@ -19,7 +19,7 @@ namespace DuoUniversal
     public class Client
     {
         public const string DUO_UNIVERSAL_CSHARP = "duo_universal_csharp";
-        public const string DUO_UNIVERSAL_CSHARP_VERSION = "1.2.1";
+        public const string DUO_UNIVERSAL_CSHARP_VERSION = "1.2.2";
 
         internal const int CLIENT_ID_LENGTH = 20;
         internal const int CLIENT_SECRET_LENGTH = 40;

--- a/DuoUniversal/Client.cs
+++ b/DuoUniversal/Client.cs
@@ -130,12 +130,12 @@ namespace DuoUniversal
         }
 
         /// <summary>
-        /// Send the authorization code provided by Duo back to Duo in exchange for a full Duo response.
+        /// Extracts and validates the Id Token from the response.
         /// Will raise a DuoException if the username does not match the Id Token.
         /// </summary>
         /// <param name="duoCode">The one-time use code issued by Duo</param>
         /// <returns>A TokenResponse authenticating the user and describing the authentication</returns>
-        private IdToken IdTokenFromResponse(TokenResponse tokenResponse, string username)
+        private IdToken ValidateIdTokenFromResponse(TokenResponse tokenResponse, string username)
         {
             IdToken idToken;
             try
@@ -169,7 +169,7 @@ namespace DuoUniversal
         public async Task<IdToken> ExchangeAuthorizationCodeFor2faResult(string duoCode, string username)
         {
             TokenResponse tokenResponse = await ExchangeAuthorizationCodeResponse(duoCode);
-            return IdTokenFromResponse(tokenResponse, username);
+            return ValidateIdTokenFromResponse(tokenResponse, username);
 
         }
 
@@ -184,10 +184,11 @@ namespace DuoUniversal
         {
             string samlResponse;
             TokenResponse tokenResponse = await ExchangeAuthorizationCodeResponse(duoCode);
-            //checking if the IdToken valid before assigning saml response
+            
             try
             {
-                IdTokenFromResponse(tokenResponse, username);
+                // Calling this method to validate the token, before getting the samlResponse value
+                ValidateIdTokenFromResponse(tokenResponse, username);
                 samlResponse = tokenResponse.SamlResponse;
             }
             catch (Exception e)

--- a/DuoUniversal/Client.cs
+++ b/DuoUniversal/Client.cs
@@ -39,7 +39,7 @@ namespace DuoUniversal
 
         internal bool UseDuoCodeAttribute { get; set; } = false;
 
-        internal string AudienceIssuer { get; set; } = null;
+        internal string audience_for_saml_response { get; set; } = null;
 
         internal Client()
         {
@@ -85,7 +85,7 @@ namespace DuoUniversal
         /// <returns>A URL to redirect the user's browser to</returns>
         public string GenerateAuthUri(string username, string state)
         {
-            ValidateAuthUriInputs(username, state, AudienceIssuer);
+            ValidateAuthUriInputs(username, state, audience_for_saml_response);
 
             string authEndpoint = CustomizeApiUri(AUTH_ENDPOINT);
 
@@ -203,9 +203,9 @@ namespace DuoUniversal
             };
 
             // issuer parameter is used for the Epic Hyperdrive integration only
-            if (AudienceIssuer != null)
+            if (audience_for_saml_response != null)
             {
-                additionalClaims[Labels.AUDIENCE_ISSUER] = AudienceIssuer;
+                additionalClaims[Labels.AUDIENCE_FOR_SAML_RESPONSE] = audience_for_saml_response;
             }
 
             if (UseDuoCodeAttribute)
@@ -311,7 +311,7 @@ namespace DuoUniversal
         private bool _sslCertValidation = true;
         private X509Certificate2Collection _customRoots = null;
         private IWebProxy proxy = null;
-        private string _audienceIssuer = null;
+        private string _audienceForSamlResponse = null;
 
 
         // For testing only
@@ -429,9 +429,9 @@ namespace DuoUniversal
         /// </summary>
         /// <param name="audienceIssuer">Specific parameter for the Epic integration for the SAML response generation</param>
         /// <returns>The ClientBuilder</returns>
-        public ClientBuilder UseAudienceIssuer(string audienceIssuer)
+        public ClientBuilder UseAudienceForSamlResponse(string audienceIssuer)
         {
-            _audienceIssuer = audienceIssuer;
+            _audienceForSamlResponse = audienceIssuer;
 
             return this;
         }
@@ -451,7 +451,7 @@ namespace DuoUniversal
                 ApiHost = _apiHost,
                 RedirectUri = _redirectUri,
                 UseDuoCodeAttribute = _useDuoCodeAttribute,
-                AudienceIssuer = _audienceIssuer
+                audience_for_saml_response = _audienceForSamlResponse
             };
 
             var httpClient = BuildHttpClient();

--- a/DuoUniversal/Client.cs
+++ b/DuoUniversal/Client.cs
@@ -39,7 +39,7 @@ namespace DuoUniversal
 
         internal bool UseDuoCodeAttribute { get; set; } = false;
 
-        internal string audience_for_saml_response { get; set; } = null;
+        internal string AudienceForSamlResponse { get; set; } = null;
 
         internal Client()
         {
@@ -85,7 +85,7 @@ namespace DuoUniversal
         /// <returns>A URL to redirect the user's browser to</returns>
         public string GenerateAuthUri(string username, string state)
         {
-            ValidateAuthUriInputs(username, state, audience_for_saml_response);
+            ValidateAuthUriInputs(username, state, AudienceForSamlResponse);
 
             string authEndpoint = CustomizeApiUri(AUTH_ENDPOINT);
 
@@ -203,9 +203,9 @@ namespace DuoUniversal
             };
 
             // issuer parameter is used for the Epic Hyperdrive integration only
-            if (audience_for_saml_response != null)
+            if (AudienceForSamlResponse != null)
             {
-                additionalClaims[Labels.AUDIENCE_FOR_SAML_RESPONSE] = audience_for_saml_response;
+                additionalClaims[Labels.AUDIENCE_FOR_SAML_RESPONSE] = AudienceForSamlResponse;
             }
 
             if (UseDuoCodeAttribute)
@@ -425,13 +425,13 @@ namespace DuoUniversal
         }
 
         /// <summary>
-        /// Set an audienceIssuer value to generate a SAML response for the Epic integration
+        /// Set an audienceForSamlResponse value to generate a SAML response for the Epic integration
         /// </summary>
-        /// <param name="audienceIssuer">Specific parameter for the Epic integration for the SAML response generation</param>
+        /// <param name="audienceForSamlResponse">Specific parameter for the Epic integration for the SAML response generation</param>
         /// <returns>The ClientBuilder</returns>
-        public ClientBuilder UseAudienceForSamlResponse(string audienceIssuer)
+        public ClientBuilder UseAudienceForSamlResponse(string audienceForSamlResponse)
         {
-            _audienceForSamlResponse = audienceIssuer;
+            _audienceForSamlResponse = audienceForSamlResponse;
 
             return this;
         }
@@ -451,7 +451,7 @@ namespace DuoUniversal
                 ApiHost = _apiHost,
                 RedirectUri = _redirectUri,
                 UseDuoCodeAttribute = _useDuoCodeAttribute,
-                audience_for_saml_response = _audienceForSamlResponse
+                AudienceForSamlResponse = _audienceForSamlResponse
             };
 
             var httpClient = BuildHttpClient();

--- a/DuoUniversal/Client.cs
+++ b/DuoUniversal/Client.cs
@@ -184,7 +184,7 @@ namespace DuoUniversal
         {
             string samlResponse;
             TokenResponse tokenResponse = await ExchangeAuthorizationCodeResponse(duoCode);
-            
+
             try
             {
                 // Calling this method to validate the token, before getting the samlResponse value

--- a/DuoUniversal/DuoUniversal.csproj
+++ b/DuoUniversal/DuoUniversal.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <PackageId>DuoUniversal</PackageId>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <Authors>Duo Security</Authors>
     <Company>Duo Security</Company>
     <Copyright>Cisco Systems, Inc. and/or its affiliates</Copyright>

--- a/DuoUniversal/DuoUniversal.csproj
+++ b/DuoUniversal/DuoUniversal.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <PackageId>DuoUniversal</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.2.6</Version>
     <Authors>Duo Security</Authors>
     <Company>Duo Security</Company>
     <Copyright>Cisco Systems, Inc. and/or its affiliates</Copyright>

--- a/DuoUniversal/DuoUniversal.csproj
+++ b/DuoUniversal/DuoUniversal.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <PackageId>DuoUniversal</PackageId>
-    <Version>1.2.4</Version>
+    <Version>1.2.5</Version>
     <Authors>Duo Security</Authors>
     <Company>Duo Security</Company>
     <Copyright>Cisco Systems, Inc. and/or its affiliates</Copyright>

--- a/DuoUniversal/DuoUniversal.csproj
+++ b/DuoUniversal/DuoUniversal.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>DuoUniversal</PackageId>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Authors>Duo Security</Authors>
     <Company>Duo Security</Company>
     <Copyright>Cisco Systems, Inc. and/or its affiliates</Copyright>

--- a/DuoUniversal/DuoUniversal.csproj
+++ b/DuoUniversal/DuoUniversal.csproj
@@ -26,9 +26,9 @@
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net471'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
     <Reference Include="System.Web" />
-	</ItemGroup>
+  </ItemGroup>
 		
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/DuoUniversal/Labels.cs
+++ b/DuoUniversal/Labels.cs
@@ -41,6 +41,6 @@ namespace DuoUniversal
         public const string DUO_UNAME = "duo_uname";
         public const string PREFERRED_USERNAME = "preferred_username";
         public const string USE_DUO_CODE_ATTRIBUTE = "use_duo_code_attribute";
-        public const string AUDIENCE_ISSUER = "issuer";
+        public const string AUDIENCE_FOR_SAML_RESPONSE = "audience_for_saml_response";
     }
 }

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ The example application has a dedicated README with further instructions on how 
 # Usage
 This library requires .NET Core 3.1 or higher, or .NET Framework 4.7.1 or higher
 
-The library is available on NuGet at https://www.nuget.org/packages/DuoUniversal/1.2.1
+The library is available on NuGet at https://www.nuget.org/packages/DuoUniversal/1.2.2
 
 Include it in your .NET project with:
 
-`dotnet add package DuoUniversal --version 1.2.1`
+`dotnet add package DuoUniversal --version 1.2.2`
 
 ## TLS 1.2 and 1.3 Support
 


### PR DESCRIPTION
The Epic integration uses the SAML response from the Duo server to handle the authentication on it's end. This change introduces the method to retrieve the SAML response in the end of the authentication in exchange to the 2FA token.

## Description
Added a method `ExchangeAuthorizationCodeForSamlResponse(string duoCode, string username)` which sends the 2FA token to the Duo server, receives the response and returns the samlResponse part of it.

## Motivation and Context
This change is a part of the bigger effort of migrating Epic integration to the Universal Prompt from the legacy implementation. For this reason the Universal Prompt needs to support the SAML response.

## How Has This Been Tested?
Added unit tests, specific for SAML response. Made sure that the existing unit tests pass

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
