### PR TITLE
feat: add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,24 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+
+
+      # NuGet doesn't support signature via signtool.exe, instead using
+      # nuget sign or dotnet nuget sign. These commands do not support
+      # detached signing. So, we have to use a different tool, jsign.
+      - name: Install jsign
+        run: choco install --ignore-dependencies jsign
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nupkg
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
@@ -37,16 +55,7 @@ jobs:
           role-session-name: jsign-kms
           aws-region: us-west-2
 
-      # NuGet doesn't support signature via signtool.exe, instead using
-      # nuget sign or dotnet nuget sign. These commands do not support
-      # detached signing. So, we have to use a different tool, jsign.
-      - name: Install jsign
-        run: choco install jsign
 
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: nupkg
       - name: Stage authenticode public certificate
         run: |
           # Pull a configured certificate parameter and write it to a specified location

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,5 +87,7 @@ jobs:
       - name: Retain signed binary
         uses: actions/upload-artifact@v4
         with:
-          path: DuoUniversal*.nupkg
+          path: |
+            authenticode.cer
+            DuoUniversal*.nupkg
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 ---
-on:
-  pull_request:
+name: Build and Sign a release
 
+on:
+  workflow_dispatch:
 
 permissions: {}
 
@@ -12,10 +13,16 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Create nuget package
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.0.100"
+
+      - name: Create NuGet package
         run: dotnet pack -c Release -o ../out
         working-directory: DuoUniversal
-      - name: Artifact the nupkg
+
+      - name: Artifact the .nupkg
         uses: actions/upload-artifact@v4
         with:
           name: nupkg
@@ -35,7 +42,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
-
 
       # NuGet doesn't support signature via signtool.exe, instead using
       # nuget sign or dotnet nuget sign. These commands do not support
@@ -78,8 +84,8 @@ jobs:
           CERT_FILE: authenticode.cer
           KEY_ID: ${{ secrets.AUTHENTICODE_KMS_KEY_ID }}
 
-      # - name: Retain signed binary
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     path: DuoUniversal*.nupkg
-      #     retention-days: 1
+      - name: Retain signed binary
+        uses: actions/upload-artifact@v4
+        with:
+          path: DuoUniversal*.nupkg
+          retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
           CERT_FILE: authenticode.cer
 
       - name: Sign nupkg
+        shell: cmd
         run: >
           jsign
             --storetype AWS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           # Pull a configured certificate parameter and write it to a specified location
           $b64 = aws ssm get-parameter `
-          --name $env:AUTHENTICODE_CERTIFICATE_PARAMETER
+          --name $env:AUTHENTICODE_CERTIFICATE_PARAMETER `
           --with-decryption `
           --query "Parameter.Value" `
           --output text

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,16 +73,10 @@ jobs:
 
       - name: Sign nupkg
         shell: cmd
-        run: >
-          jsign
-            --storetype AWS
-            --keystore us-west-2
-            --alias $env:KEY_ID
-            --certfile $env:CERT_FILE
-            DuoUniversal*.nupkg
-          env:
-            CERT_FILE: authenticode.cer
-            KEY_ID: ${{ secrets.AUTHENTICODE_KMS_KEY_ID }}
+        run: jsign --storetype AWS --keystore us-west-2 --alias $env:KEY_ID --certfile $env:CERT_FILE DuoUniversal*.nupkg
+        env:
+          CERT_FILE: authenticode.cer
+          KEY_ID: ${{ secrets.AUTHENTICODE_KMS_KEY_ID }}
 
       # - name: Retain signed binary
       #   uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,6 @@ on:
 permissions: {}
 
 jobs:
-  test:
-    runs-on: windows-2022
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test C#
-        run: dotnet test
-
   package:
     runs-on: windows-2022
     permissions:
@@ -34,6 +25,7 @@ jobs:
   sign:
     runs-on: windows-2022
     environment: authenticode-signing
+    needs: package
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 ---
 on:
-  pull-request:
+  pull_request:
 
 jobs:
-  - name: Test signing
+  release:
     uses: cisco-sbg/ZT-duo_universal_csharp_ci/.github/workflows/sign_and_package.yml@5c673525a3fc07bfb93bd4f18304fb66763525d7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Sign nupkg
         shell: cmd
-        run: jsign --storetype AWS --keystore us-west-2 --alias $env:KEY_ID --certfile $env:CERT_FILE DuoUniversal*.nupkg
+        run: jsign --storetype AWS --keystore us-west-2 --alias %KEY_ID% --certfile %CERT_FILE% DuoUniversal*.nupkg
         env:
           CERT_FILE: authenticode.cer
           KEY_ID: ${{ secrets.AUTHENTICODE_KMS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,88 @@
 on:
   pull_request:
 
+
+permissions: {}
+
 jobs:
-  release:
-    uses: cisco-sbg/ZT-duo_universal_csharp_ci/.github/workflows/sign_and_package.yml@5c673525a3fc07bfb93bd4f18304fb66763525d7
+  test:
+    runs-on: windows-2022
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test C#
+        run: dotnet test
+
+  package:
+    runs-on: windows-2022
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create nuget package
+        run: dotnet pack -c Release -o ../out
+        working-directory: DuoUniversal
+      - name: Artifact the nupkg
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg
+          path: out/DuoUniversal*.nupkg
+          retention-days: 1
+
+  sign:
+    runs-on: windows-2022
+    environment: authenticode-signing
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        with:
+          role-to-assume: ${{ secrets.AUTHENTICODE_ROLE_ARN }}
+          role-session-name: jsign-kms
+          aws-region: us-west-2
+
+      # NuGet doesn't support signature via signtool.exe, instead using
+      # nuget sign or dotnet nuget sign. These commands do not support
+      # detached signing. So, we have to use a different tool, jsign.
+      - name: Install jsign
+        run: choco install jsign
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nupkg
+      - name: Stage authenticode public certificate
+        run: |
+          # Pull a configured certificate parameter and write it to a specified location
+          $b64 = aws ssm get-parameter `
+          --name $env:AUTHENTICODE_CERTIFICATE_PARAMETER
+          --with-decryption `
+          --query "Parameter.Value" `
+          --output text
+          $bytes = [Convert]::FromBase64String($b64)
+          [IO.File]::WriteAllBytes($env:CERT_FILE, $bytes)
+          [System.Security.Cryptography.X509Certificates.X509Certificate2]::CreateFromCertFile($env:CERT_FILE) | Select-Object "*"
+        env:
+          AUTHENTICODE_CERTIFICATE_PARAMETER: ${{ secrets.AUTHENTICODE_CERTIFICATE_PARAMETER }}
+          CERT_FILE: authenticode.cer
+
+      - name: Sign nupkg
+        run: >
+          jsign
+            --storetype AWS
+            --keystore us-west-2
+            --alias $env:KEY_ID
+            --certfile $env:CERT_FILE
+            DuoUniversal*.nupkg
+          env:
+            CERT_FILE: authenticode.cer
+            KEY_ID: ${{ secrets.AUTHENTICODE_KMS_KEY_ID }}
+
+      # - name: Retain signed binary
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     path: DuoUniversal*.nupkg
+      #     retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,7 @@
+---
+on:
+  pull-request:
+
+jobs:
+  - name: Test signing
+    uses: cisco-sbg/ZT-duo_universal_csharp_ci/.github/workflows/sign_and_package.yml@5c673525a3fc07bfb93bd4f18304fb66763525d7

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,0 @@
-include:
-  - project: "mirrors/duo_universal_csharp_ci"
-    ref: "main"
-    file: ".gitlab-ci.yml"


### PR DESCRIPTION
## Description

This PR adds a package and sign workflow. It uses [jsign](https://ebourg.github.io/jsign/) to enable signing with an HSM-controlled key.

## Motivation and Context

Our current signing certificate was generated from a private key itself generated in an HSM. It is not easy to use `dotnet sign` or `dotnet nuget sign` with the HSM-backed key.

Similarly, our internal CI is moving from GitLab to GitHub Actions. It is not possible for a public repository to pull workflows or actions from a private one, so we have to implement this part of our release process locally.

## How Has This Been Tested?

We validated that signing works by temporarily having a PR sign (and discard) a .nupkg.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
