### PR TITLE
Added pinner to disable only pinning

### DIFF
--- a/DuoUniversal/CertificatePinnerFactory.cs
+++ b/DuoUniversal/CertificatePinnerFactory.cs
@@ -52,6 +52,19 @@ namespace DuoUniversal
         }
 
         /// <summary>
+        /// Get a certificate validator that performs standard chain validation (trust, expiry, hostname)
+        /// but does not enforce certificate pinning.
+        /// </summary>
+        /// <returns>A certificate validator for use in an HttpClientHandler</returns>
+        public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> GetCertificateValidatorWithoutPinning()
+        {
+            return (httpRequestMessage, certificate, chain, sslPolicyErrors) =>
+            {
+                return sslPolicyErrors == SslPolicyErrors.None;
+            };
+        }
+
+        /// <summary>
         /// Get a certificate pinner that ensures only connections to the root certificates provided to the constructor are allowed
         /// </summary>
         /// <returns>A certificate pinner for use in an HttpClientHandler</returns>

--- a/DuoUniversal/Client.cs
+++ b/DuoUniversal/Client.cs
@@ -361,6 +361,7 @@ namespace DuoUniversal
         private string _additionalUserAgentString;
         private bool _useDuoCodeAttribute = false;
         private bool _sslCertValidation = true;
+        private bool _enableCertPinning = true;
         private X509Certificate2Collection _customRoots = null;
         private IWebProxy proxy = null;
         private string _audienceForSamlResponse = null;
@@ -398,10 +399,23 @@ namespace DuoUniversal
             return this;
         }
 
+        /// <summary>
+        /// Disables certificate pinning while preserving standard SSL/TLS certificate validation.
+        /// The connection will still verify certificate trust, expiry, and hostname — only the
+        /// additional pin check against Duo's root certificate hashes is removed.
+        /// </summary>
+        /// <returns>The ClientBuilder</returns>
+        public ClientBuilder DisableCertificatePinning()
+        {
+            _enableCertPinning = false;
+
+            return this;
+        }
+
         ///  <summary>
         /// Disables SSL certificate validation for the API calls the client makes.
         /// Incomptible with UseCustomRootCertificates since certificates will not be checked.
-        /// 
+        ///
         /// THIS SHOULD NEVER BE USED IN A PRODUCTION ENVIRONMENT
         /// </summary>
         /// <returns>The ClientBuilder</returns>
@@ -565,6 +579,11 @@ namespace DuoUniversal
             if (!_sslCertValidation)
             {
                 return CertificatePinnerFactory.GetCertificateDisabler();
+            }
+
+            if (!_enableCertPinning)
+            {
+                return CertificatePinnerFactory.GetCertificateValidatorWithoutPinning();
             }
 
             if (_customRoots != null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added method to disable certificate pinning. Right now you can only disable all certificate validation which is not ideal. This will allow other repos to set pinning based off their own information every call.

## Motivation and Context
Duo applications need to be able to allow users to enable or disable certificate pinning. Otherwise pinning will block any customers using proxies, as well as other issues.

## How Has This Been Tested?
Wired up to registry and tested changes. Worked correctly.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
